### PR TITLE
Fix for crash on null device

### DIFF
--- a/lib/api-functions.coffee
+++ b/lib/api-functions.coffee
@@ -141,7 +141,7 @@ connectionRequest = (deviceId, callback) ->
   }
 
   db.devicesCollection.findOne({_id : deviceId}, proj, (err, device)->
-    return callback(err) if err
+    return callback(err) if err or !device
 
     if device.Device? # TR-181 data model
       connectionRequestUrl = device.Device.ManagementServer.ConnectionRequestURL._value


### PR DESCRIPTION
This fixes a crash in the NBI when the device isn't found in Mongo. Scenario is sending GPV for a device that hasn't yet registered.

Fixed #226