### PR TITLE
Using if instead of -n in copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "prepublish": "npm run compile",
     "compile": "coffee -cb lib/*.coffee",
-    "configure": "cp -n ./config/config-sample.json ./config/config.json",
+    "configure": "if [ ! -f ./config/config.json ]; then cp ./config/config-sample.json ./config/config.json; fi",
     "install": "npm run configure",
     "test": "node test"
   }


### PR DESCRIPTION
Alpine linux does not have -n option in copy binary.
To avoid a problem on configure, I replaced the command with an "if".
Now it works in every UNIX cp command.