### PR TITLE
prevent uncaught exception exceptionName="TypeError" exceptionMessage…

### DIFF
--- a/lib/api-functions.js
+++ b/lib/api-functions.js
@@ -29,7 +29,7 @@ const auth = require("./auth");
 const cache = require("./cache");
 
 function udpConReq(address, un, key, callback) {
-  if (!address) return false;
+  if (!address || !un || !key) return false;
 
   let [host, port] = address.split(":", 2);
 


### PR DESCRIPTION
issue #332 describes NBI's behaviour if `un` or `key` parameter are undefined.

https://github.com/genieacs/genieacs/blob/4c2a81f94e14fd3998131f5b249c8bea99087027/lib/api-functions.js#L31