### PR TITLE
Providing the remote address of the requesting cpe to the sandbox

### DIFF
--- a/lib/sandbox.ts
+++ b/lib/sandbox.ts
@@ -310,12 +310,19 @@ function log(msg: string, meta: {}): void {
   }
 }
 
+function getRequestDetail(): any {
+  let detail = {};
+  detail["remoteAddress"] = state.sessionContext.httpRequest.connection.remoteAddress;
+  return detail;
+}
+
 Object.defineProperty(context, "Date", { value: SandboxDate });
 Object.defineProperty(context, "declare", { value: declare });
 Object.defineProperty(context, "clear", { value: clear });
 Object.defineProperty(context, "commit", { value: commit });
 Object.defineProperty(context, "ext", { value: ext });
 Object.defineProperty(context, "log", { value: log });
+Object.defineProperty(context, "getRequestDetail", { value: getRequestDetail});
 
 // Monkey-patch Math.random() to make it deterministic
 context.random = random;


### PR DESCRIPTION
As mentioned here https://forum.genieacs.com/t/request-ip-behind-nat/139 this provides the ability to hand over some additional information about the requesting cpe which could be useful in provisioning scripts. I am not sure if this is the way you intend but it works well.

To use it in a provisioning script one could simply:
```
let requestDetail = getRequestDetail();
log("Request-IP: " + requestDetail["remoteAddress"]);
```