### PR TITLE
Fixing crash shown on genieacs forum post #1008

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -692,10 +692,15 @@ export async function getOperations(
     const commandKey = r._id.slice(deviceId.length + 1);
     delete r._id;
     r.timestamp = +r.timestamp;
-    if (r.args) r.args = JSON.parse(r.args);
-    r.provisions = JSON.parse(r.provisions);
-    r.retries = JSON.parse(r.retries);
-    operations[commandKey] = r;
+    try {
+      if (r.args) r.args = JSON.parse(r.args);
+      r.provisions = JSON.parse(r.provisions);
+      r.retries = JSON.parse(r.retries);
+    } catch (e) {
+      //Dont panic, r.args is already javascript
+    } finally {
+      operations[commandKey] = r;
+    }
   }
   return operations;
 }


### PR DESCRIPTION
As shown here [https://forum.genieacs.com/t/genieacs-specific-packet-crash/1008/2](https://forum.genieacs.com/t/genieacs-specific-packet-crash/1008/3)

Steps to reproduce:
MongoDB version 4.4.0
GenieACS version 1.2.0+
NodeJS version 12.18.3

Push a RPC download (3 Vendor Configuration File) to the CPE (I'm using Mikrotik ARM based RouterOS version 6.47.3)




cwmp service was crashing after an operation was created for a device.

Putting the JSON.parse inside a _try ... catch ... finally_ construct will work either if r.args (and other objects) are JSON strings or JS objects.
