### PR TITLE
Bind the digest authentication to serial instead of tcp session

### DIFF
--- a/lib/cluster.ts
+++ b/lib/cluster.ts
@@ -110,6 +110,10 @@ export function start(
   });
 
   cluster.on("exit", restartWorker);
+  cluster.on("message", function(_,message){
+    for(var i in cluster.workers)
+      cluster.workers[i].send(message);
+  })
 
   if (!workerCount) workerCount = Math.max(2, cpus().length);
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3935,6 +3935,21 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
+    "node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "requires": {
+        "clone": "2.x"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+        }
+      }
+    },
     "node-releases": {
       "version": "1.1.26",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "koa-static": "^5.0.0",
     "later": "^1.2.0",
     "mongodb": "^3.6.2",
+    "node-cache": "^5.1.2",
     "parsimmon": "^1.16.0",
     "seedrandom": "^3.0.5"
   },


### PR DESCRIPTION
Hi,
while testing the CPE -> ACS authentication we had troubles with the AVM Fritzbox models as CPE.
At least in our setting the CPE's initiated a new connection once they received an Unauthorized response.
Cause of this the ACS could not match the new connection to the send Nonce thus rejecting the otherwise correct authentication.

To fix this I bound the nonce map to the CPE serial instead of the socket and used the cluster IPC to communicate the nonces between multiple works.
To avoid filling up memory with mapped serials:nonces i used the node-cache library to expire mappings after 60s and automaticly remove them.

Node-cache currently has a limitation of ~1m keys, so I choose the relatively small TTL to deal even with high load scenarios.