### PR TITLE
Allows to define own URL Prefix for device Links

### DIFF
--- a/ui/components/device-link.ts
+++ b/ui/components/device-link.ts
@@ -24,8 +24,12 @@ const component: ClosureComponent = (): Component => {
   return {
     view: (vnode) => {
       let deviceId;
+      let prefix= "#!/devices/"
       if (vnode.attrs["device"])
         deviceId = vnode.attrs["device"]["DeviceID.ID"].value[0];
+      if (vnode.attrs["urlPrefix"])
+        prefix=vnode.attrs["urlPrefix"];
+
 
       const children = Object.values(vnode.attrs["components"]).map((c) => {
         if (typeof c !== "object") return `${c}`;
@@ -35,7 +39,7 @@ const component: ClosureComponent = (): Component => {
       if (deviceId) {
         return m(
           "a",
-          { href: `#!/devices/${encodeURIComponent(deviceId)}` },
+          { href: `${prefix}${encodeURIComponent(deviceId)}` },
           children
         );
       } else {


### PR DESCRIPTION
e.G. to connect to other services
example usage:
- label: "'Serial number'"
  parameter: "'GRAPH'"
  type: "'device-link'"
  urlPrefix: "'https://acs/graph/'"
  components:
    - type: "'parameter'"

This will create a Link with this url 
https://acs/graph/00040E-FRITZ%2521Box-000000000
This can be used to jump to other services that use genieacs as a backend, like an diy speedtest service.