### PR TITLE
Add HTTP request header authentication to NBI

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -56,6 +56,7 @@ const options = {
   NBI_SSL_KEY: { type: "string", default: "" },
   NBI_LOG_FILE: { type: "path", default: "" },
   NBI_ACCESS_LOG_FILE: { type: "path", default: "" },
+  NBI_AUTHENTICATION_KEY: { type: "string", default: "" },
 
   FS_WORKER_PROCESSES: { type: "int", default: 0 },
   FS_PORT: { type: "int", default: 7567 },


### PR DESCRIPTION
This PR provides an HTTP-header-based NBI authentication solution for the security issue raised in this forum post:
https://forum.genieacs.com/t/secure-rest-api-endpoints-of-genieacs-nbi/1093

The solution adds an optional configuration parameter "NBI_AUTHENTICATION_KEY", which - when present - is required to be present in an "x-api-key" HTTP header of any incoming request.  When the "NBI_AUTHENTICATION_KEY" configuration parameter is absent, the current behaviour stands i.e. no authentication is required.