### PR TITLE
Added skip() and limit() to paginate results from API query

### DIFF
--- a/lib/nbi.ts
+++ b/lib/nbi.ts
@@ -826,6 +826,10 @@ export function listener(
 
       const cur = collection.find(q, { projection: projection });
 
+      if(urlParts.query.limit && urlParts.query.skip) {
+	      const cur = collection.find(q, { projection: projection }).skip(Number(urlParts.query.skip)).limit(Number(urlParts.query.limit));
+      }
+
       if (urlParts.query.sort) {
         let s;
         try {


### PR DESCRIPTION
Hello,

I've added a way to paginate results from API response using the collection skip() and limit(). Using this you can send in the query string the 'skip=X' and 'limit=Y' to offset and limit the responses coming from API.
