### PR TITLE
various sandbox improvements

### DIFF
--- a/docs/environment-variables.rst
+++ b/docs/environment-variables.rst
@@ -215,3 +215,12 @@ UI_JWT_SECRET
   string can be up to 64 characters in length.
 
   Default: unset
+
+ENVIRONMENT
+  Name to differentiate deployment environments. This will be made available in 
+  the sandbox and can be used to make specific branches.
+
+  Default: development
+
+FORWARDED_HEADER
+  Range(s) of IP address that are allowed to set the forwarded HTTP header. (reverse proxys) This is used to extract te remote IP of a provision session for logging and scripting purposes.  

--- a/docs/provisions.rst
+++ b/docs/provisions.rst
@@ -136,6 +136,32 @@ debugging. Note that you may see multiple log entries as the script can be
 executed multiple times in a session. See :ref:`this FAQ
 <administration-faq-duplicate-log-entries>`.
 
+``getRequestOriginRemoteAddress()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Returns the remote address of the CPE (initiator of the current provisioning session). 
+
+This function supports the HTTP forwarded header in the same way that logging does. (FORWARDED_HEADER config should allow the intermediate host) 
+
+It can be used as a security measure. E.g. when there is no individual CPE to ACS authentication the remote address can be matched against the claimed
+address.
+
+``require``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+NodeJS buid-in require function made available in the sandbox. This can be used to load custom helper functions shared accros multiple scripts.
+Make sure that the required module is in the NODE_PATH
+
+Built-in variables
+------------------
+
+``environment``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Value of the ENVIRONMENT config (setable via GENIEAC_ENVIRONMENT system env var).
+Can be used to build portable provisions between various environments. e.g. development, test, staging, production
+
+
 .. _path-format:
 
 Path format

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -98,6 +98,7 @@ const options = {
   BOOLEAN_LITERAL: { type: "bool", default: true },
   CONNECTION_REQUEST_ALLOW_BASIC_AUTH: { type: "bool", default: false },
   MAX_COMMIT_ITERATIONS: { type: "int", default: 32 },
+  ENVIRONMENT: { type: "string", default: "development" },
 
   // Should probably never be changed
   DEVICE_ONLINE_THRESHOLD: { type: "int", default: 4000 },

--- a/lib/sandbox.ts
+++ b/lib/sandbox.ts
@@ -25,6 +25,8 @@ import * as logger from "./logger";
 import * as scheduling from "./scheduling";
 import Path from "./common/path";
 import { Fault, SessionContext, ScriptResult } from "./types";
+import { getRequestOrigin } from "./forwarded";
+import * as config from "./config";
 
 // Used for throwing to exit user script and commit
 const COMMIT = Symbol();
@@ -321,12 +323,19 @@ function log(msg: string, meta: Record<string, unknown>): void {
   }
 }
 
+function getRequestOriginRemoteAddress(): any {
+  return getRequestOrigin(state.sessionContext.httpRequest).remoteAddress;
+}
+
 Object.defineProperty(context, "Date", { value: SandboxDate });
 Object.defineProperty(context, "declare", { value: declare });
 Object.defineProperty(context, "clear", { value: clear });
 Object.defineProperty(context, "commit", { value: commit });
 Object.defineProperty(context, "ext", { value: ext });
 Object.defineProperty(context, "log", { value: log });
+Object.defineProperty(context, "getRequestOriginRemoteAddress", { value: getRequestOriginRemoteAddress});
+Object.defineProperty(context, "environment", { value: config.get("ENVIRONMENT")});
+Object.defineProperty(context, "require", { value: require});
 
 // Monkey-patch Math.random() to make it deterministic
 context.random = random;


### PR DESCRIPTION
Hi,

I've made some improvements to the sandbox in order to better manage configuration (scripts) across multiple environments and to be able to do some security/sanity checks.

This duplicates a part of the functionality from [Providing the remote address of the requesting CPE to the sandbox ](https://github.com/genieacs/genieacs/pull/347#issue-457368925), but with added support for the HTTP forwarded header.

I've updated the docs as well.  Let me know if you would like some adjustments to better fit the overall architecture.

Best Regards,

Timo