### PR TITLE
Add ACS SSL Link

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -44,6 +44,7 @@ const options = {
   CWMP_WORKER_PROCESSES: { type: "int", default: 0 },
   CWMP_PORT: { type: "int", default: 7547 },
   CWMP_INTERFACE: { type: "string", default: "::" },
+  CWMP_SSL_PORT: { type: "int", default: 7546 },
   CWMP_SSL_CERT: { type: "string", default: "" },
   CWMP_SSL_KEY: { type: "string", default: "" },
   CWMP_LOG_FILE: { type: "path", default: "" },


### PR DESCRIPTION
When you add the CWMP_SSL_CERT and CWMP_SSL_KEY values, you must connect to the genieACS link using HTTPS only, which may affect CPEs that are currently connected using regular HTTP or CPEs that do not support HTTPS ACS links. Ideally, I would add a connection on port 7546 that supports HTTPS to accommodate this.