### PR TITLE
Strange "Invalid session" error message 

### DIFF
--- a/build/build.ts
+++ b/build/build.ts
@@ -51,6 +51,8 @@ const externals = [
   "tls",
   "http",
   "https",
+  "net",
+  "events",
   "zlib",
   "crypto",
   "util",

--- a/lib/api-functions.ts
+++ b/lib/api-functions.ts
@@ -50,6 +50,7 @@ export async function connectionRequest(
 
   let connectionRequestUrl,
     udpConnectionRequestAddress,
+    stunEnable,
     connReqJabberId,
     username,
     password;
@@ -62,6 +63,9 @@ export async function connectionRequest(
       device[
         "InternetGatewayDevice.ManagementServer.UDPConnectionRequestAddress"
       ] || {}
+    ).value || [""])[0];
+    stunEnable = ((
+      device["InternetGatewayDevice.ManagementServer.STUNEnable"] || {}
     ).value || [""])[0];
     connReqJabberId = ((
       device["InternetGatewayDevice.ManagementServer.ConnReqJabberID"] || {}
@@ -83,6 +87,8 @@ export async function connectionRequest(
     udpConnectionRequestAddress = ((
       device["Device.ManagementServer.UDPConnectionRequestAddress"] || {}
     ).value || [""])[0];
+    stunEnable = ((device["Device.ManagementServer.STUNEnable"] || {})
+      .value || [""])[0];
     connReqJabberId = ((device["Device.ManagementServer.ConnReqJabberID"] || {})
       .value || [""])[0];
     username = ((
@@ -159,7 +165,7 @@ export async function connectionRequest(
   const debug = !!getConfig(snapshot, "cwmp.debug", {}, now, evalCallback);
 
   let udpProm;
-  if (udpConnectionRequestAddress) {
+  if (udpConnectionRequestAddress && +stunEnable) {
     udpProm = udpConnectionRequest(
       udpConnectionRequestAddress,
       authExp,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -101,6 +101,9 @@ const options = {
 
   // Should probably never be changed
   DEVICE_ONLINE_THRESHOLD: { type: "int", default: 4000 },
+
+  XMPP_JID: { type: "string", default: "" },
+  XMPP_PASSWORD: { type: "string", default: "" },
 };
 
 const allConfig: { [name: string]: string | number } = {};

--- a/lib/connection-request.ts
+++ b/lib/connection-request.ts
@@ -244,11 +244,8 @@ const XMPP_PASSWORD = config.get("XMPP_PASSWORD") as string;
 const XMPP_RESOURCE = crypto.randomBytes(8).toString("hex");
 
 let xmppClient: XmppClient;
-let xmppclientTimeout: NodeJS.Timeout;
 
 function xmppClientOnError(err: Error): void {
-  clearTimeout(xmppclientTimeout);
-  xmppClient.disconnect();
   xmppClient = null;
   logger.error({
     message: "XMPP exception",
@@ -257,8 +254,7 @@ function xmppClientOnError(err: Error): void {
   });
 }
 
-function xmppClientTimeoutCallback(): void {
-  xmppClient.disconnect();
+function xmppClientOnClose(): void {
   xmppClient = null;
 }
 
@@ -276,11 +272,12 @@ export async function xmppConnectionRequest(
       username,
       resource: XMPP_RESOURCE,
       password: XMPP_PASSWORD,
+      timeout: 120000,
     });
     xmppClient.on("error", xmppClientOnError);
+    xmppClient.on("close", xmppClientOnClose);
+    xmppClient.unref();
   }
-  clearTimeout(xmppclientTimeout);
-  setTimeout(xmppClientTimeoutCallback, 120000);
 
   let username: string;
   let password: string;

--- a/lib/debug.ts
+++ b/lib/debug.ts
@@ -202,3 +202,37 @@ export function outgoingUdpMessage(
     appendFileSync(DEBUG_FILE, JSON.stringify(msg) + "\n");
   else throw new Error(`Unrecognized DEBUG_FORMAT option`);
 }
+
+export function outgoingXmppStanza(deviceId: string, body: string): void {
+  if (!DEBUG_FILE) return;
+  const now = new Date();
+  const msg = {
+    event: "outgoing XMPP stanza",
+    timestamp: now,
+    deviceId: deviceId,
+    body: body,
+  };
+
+  if (DEBUG_FORMAT === "yaml")
+    appendFileSync(DEBUG_FILE, "---\n" + yaml.stringify(msg));
+  else if (DEBUG_FORMAT === "json")
+    appendFileSync(DEBUG_FILE, JSON.stringify(msg) + "\n");
+  else throw new Error(`Unrecognized DEBUG_FORMAT option`);
+}
+
+export function incomingXmppStanza(deviceId: string, body: string): void {
+  if (!DEBUG_FILE) return;
+  const now = new Date();
+  const msg = {
+    event: "incoming XMPP stanza",
+    timestamp: now,
+    deviceId: deviceId,
+    body: body,
+  };
+
+  if (DEBUG_FORMAT === "yaml")
+    appendFileSync(DEBUG_FILE, "---\n" + yaml.stringify(msg));
+  else if (DEBUG_FORMAT === "json")
+    appendFileSync(DEBUG_FILE, JSON.stringify(msg) + "\n");
+  else throw new Error(`Unrecognized DEBUG_FORMAT option`);
+}

--- a/lib/xmpp-client.ts
+++ b/lib/xmpp-client.ts
@@ -295,10 +295,8 @@ function* init(
         throw new Error("No supported SASL method");
       }
     } else if (feature.name === "bind") {
-      if (feature.children.some((c) => c.name === "required")) {
-        yield* bind(socket, resource);
-        return 0;
-      }
+      yield* bind(socket, resource);
+      return 0;
     }
   }
   return 0;

--- a/lib/xmpp-client.ts
+++ b/lib/xmpp-client.ts
@@ -1,0 +1,388 @@
+/**
+ * Copyright 2013-2020  GenieACS Inc.
+ *
+ * This file is part of GenieACS.
+ *
+ * GenieACS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GenieACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with GenieACS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as net from "net";
+import * as tls from "tls";
+import { EventEmitter } from "events";
+import { createHash, createHmac, randomBytes } from "crypto";
+import { parseXml, Element, parseAttrs } from "./xml-parser";
+
+function encodeBase64(str: string): string {
+  return Buffer.from(str).toString("base64");
+}
+
+function decodeBase64(str: string): string {
+  return Buffer.from(str, "base64").toString();
+}
+
+function detectStreamTag(data: string): number {
+  const i1 = data.indexOf("<stream:stream");
+  if (i1 < 0) throw new Error("Cannot detect opening stream tag");
+  const i2 = data.indexOf(">", i1);
+  if (i2 < 0) throw new Error("Cannot detect opening stream tag");
+  return i2 + 1;
+}
+
+function xmppStream<T>(
+  socket: net.Socket,
+  callback: Generator<void, T, Element>
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const onError = (err: Error): void => {
+      socket.removeListener("error", onError);
+      reject(err);
+    };
+    socket.on("error", onError);
+
+    const onData = (chunk: Buffer): void => {
+      try {
+        const str = chunk.toString("utf8");
+        const xml = parseXml(str);
+        const { value, done } = callback.next(xml.children[0]);
+        if (done) {
+          socket.removeListener("error", onError);
+          socket.removeListener("data", onData);
+          resolve(value as T);
+        }
+      } catch (err) {
+        socket.removeListener("error", onError);
+        socket.removeListener("data", onData);
+        reject(err);
+      }
+    };
+
+    socket.once("data", (chunk: Buffer) => {
+      try {
+        const str = chunk.toString("utf8");
+        const i = detectStreamTag(str);
+        const streamTagStr = str.slice(0, i);
+        const xml = parseXml(streamTagStr + "</stream:stream>");
+        callback.next(xml.children[0]);
+        chunk = chunk.slice(Buffer.byteLength(streamTagStr));
+        if (chunk.length) onData(chunk);
+        socket.on("data", onData);
+      } catch (err) {
+        socket.removeListener("error", onError);
+        socket.removeListener("data", onData);
+        reject(err);
+      }
+    });
+
+    try {
+      callback.next();
+    } catch (err) {
+      socket.removeListener("error", onError);
+      socket.removeListener("data", onData);
+      reject(err);
+    }
+  });
+}
+
+const INT_1 = Buffer.from([0, 0, 0, 1]);
+const saltedPasswordCache = {
+  password: "",
+  iterationCount: 0,
+  saltBase64: "",
+  salted: Buffer.allocUnsafe(0),
+};
+
+function saltPassword(
+  password: string,
+  saltBase64: string,
+  iteractionCount: number
+): Buffer {
+  if (
+    password === saltedPasswordCache.password &&
+    saltBase64 === saltedPasswordCache.saltBase64 &&
+    iteractionCount === saltedPasswordCache.iterationCount
+  )
+    return saltedPasswordCache.salted;
+
+  const hi = createHmac("sha1", password)
+    .update(Buffer.concat([Buffer.from(saltBase64, "base64"), INT_1]))
+    .digest();
+  let hi2: Buffer = hi;
+  for (let i = 1; i < iteractionCount; ++i) {
+    hi2 = createHmac("sha1", password).update(hi2).digest();
+    for (const [j, b] of hi2.entries()) hi[j] ^= b;
+  }
+
+  saltedPasswordCache.saltBase64 = saltBase64;
+  saltedPasswordCache.password = password;
+  saltedPasswordCache.iterationCount = iteractionCount;
+  saltedPasswordCache.salted = hi;
+
+  return hi;
+}
+
+function* login(
+  socket: net.Socket,
+  username: string,
+  password: string
+): Generator<void, void, Element> {
+  const cnonce = randomBytes(8).toString("base64");
+  const gs2Header = "n,,";
+  const clientFirstMessageBare = `n=${username},r=${cnonce}`;
+  const clientFirstMessage = gs2Header + clientFirstMessageBare;
+  socket.write(
+    `<auth xmlns="urn:ietf:params:xml:ns:xmpp-sasl" mechanism="SCRAM-SHA-1">${encodeBase64(
+      clientFirstMessage
+    )}</auth>`
+  );
+  const res1 = yield;
+  if (res1.name !== "challenge")
+    throw new Error(`Unexpected element ${res1.name}`);
+  const serverFirstMessage = decodeBase64(res1.text);
+
+  let iterationCount: number;
+  let saltBase64: string;
+  let nonce: string;
+  for (const s of serverFirstMessage.split(",")) {
+    if (s.startsWith("i=")) iterationCount = parseInt(s.slice(2));
+    else if (s.startsWith("s=")) saltBase64 = s.slice(2);
+    else if (s.startsWith("r=")) nonce = s.slice(2);
+  }
+  if (iterationCount == null || isNaN(iterationCount))
+    throw new Error("Invalid iteration count");
+  if (saltBase64 == null) throw new Error("Missing salt");
+  if (nonce == null) throw new Error("Missing nonce");
+
+  const saltedPassword = saltPassword(password, saltBase64, iterationCount);
+  const clientKey = createHmac("sha1", saltedPassword)
+    .update("Client Key")
+    .digest();
+  const storedKey = createHash("sha1").update(clientKey).digest();
+
+  const clientFinalMessageWithoutProof = `c=${encodeBase64(
+    gs2Header
+  )},r=${nonce}`;
+  const authMessage = `${clientFirstMessageBare},${serverFirstMessage},${clientFinalMessageWithoutProof}`;
+  const clientSignature = createHmac("sha1", storedKey)
+    .update(authMessage)
+    .digest();
+
+  const clientProof = Buffer.from(clientKey);
+  for (const [i, b] of clientSignature.entries()) clientProof[i] ^= b;
+
+  const clientFinalMessage = `${clientFinalMessageWithoutProof},p=${clientProof.toString(
+    "base64"
+  )}`;
+  socket.write(
+    `<response xmlns="urn:ietf:params:xml:ns:xmpp-sasl">${encodeBase64(
+      clientFinalMessage
+    )}</response>`
+  );
+  const res2 = yield;
+
+  if (
+    res2.name === "failure" &&
+    res2.children.some((c) => c.name === "not-authorized")
+  )
+    throw new Error("Not authorized");
+
+  if (res2.name !== "success")
+    throw new Error(`Unexpected response ${res2.name}`);
+
+  const serverKey = createHmac("sha1", saltedPassword)
+    .update("Server Key")
+    .digest();
+  const serverSignature = createHmac("sha1", serverKey)
+    .update(authMessage)
+    .digest("base64");
+
+  if (!decodeBase64(res2.text).endsWith(serverSignature))
+    throw new Error("Invalid server signature");
+}
+
+function* starttls(socket: net.Socket): Generator<void, void, Element> {
+  socket.write("<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>");
+  const res1 = yield;
+  if (res1.name !== "proceed") throw new Error("Failed to initiate STARTTLS");
+}
+
+function* bind(
+  socket: net.Socket,
+  resource: string
+): Generator<void, void, Element> {
+  const id = randomBytes(8).toString("base64");
+  socket.write(
+    `<iq id='${id}' type='set'><bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'><resource>${resource}</resource></bind></iq>`
+  );
+  const res1 = yield;
+  if (res1.name !== "iq") throw new Error(`Unexpected element ${res1.name}`);
+  const attrs1 = parseAttrs(res1.attrs);
+  const idAttr = attrs1.find((a) => a.name === "id");
+  if (!idAttr || idAttr.value !== id) throw new Error("Invalid ID");
+  const typeAttr = attrs1.find((a) => a.name === "type");
+  if (!typeAttr) throw new Error("Missing type attribute");
+  if (typeAttr.value !== "result") throw new Error("Cannot bind to resource");
+}
+
+const STATUS_RESTART_STREAM = 1;
+const STATUS_STARTTLS = 2;
+
+function* init(
+  socket: net.Socket,
+  host: string,
+  username: string,
+  password: string,
+  resource: string
+): Generator<void, number, Element> {
+  socket.write(
+    `<?xml version='1.0'?><stream:stream from='${username}@${host}' to='${host}' version='1.0' xml:lang='en' xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'>`
+  );
+  const open = yield;
+  if (open.name !== "stream:stream")
+    throw new Error(`Unexpected element ${open.name}`);
+  const features = yield;
+  if (features.name !== "stream:features")
+    throw new Error(`Unexpected element ${features.name}`);
+  for (const feature of features.children) {
+    if (feature.name === "starttls") {
+      if (feature.children.some((c) => c.name === "required")) {
+        yield* starttls(socket);
+        return STATUS_STARTTLS;
+      }
+    } else if (feature.name === "mechanisms") {
+      const mechanisms: Set<string> = new Set(
+        feature.children.map((c) => c.text)
+      );
+      if (mechanisms.has("SCRAM-SHA-1")) {
+        yield* login(socket, username, password);
+        return STATUS_RESTART_STREAM;
+      }
+    } else if (feature.name === "bind") {
+      if (feature.children.some((c) => c.name === "required")) {
+        yield* bind(socket, resource);
+        return 0;
+      }
+    }
+  }
+  return 0;
+}
+
+function upgradeTls(socket: net.Socket, host: string): Promise<tls.TLSSocket> {
+  return new Promise((resolve, reject) => {
+    socket.on("error", reject);
+    const newSocket = tls.connect({ socket, host }, () => {
+      socket.removeListener("error", reject);
+      resolve(newSocket);
+    });
+  });
+}
+
+interface XmppClientOptions {
+  host: string;
+  port?: number;
+  username?: string;
+  password?: string;
+  resource?: string;
+}
+
+export class XmppClient extends EventEmitter {
+  private _socket: net.Socket;
+  private _host: string;
+  private _username: string;
+  private _resource: string;
+
+  private constructor() {
+    super();
+    this._socket = null;
+    this._host = null;
+    this._username = null;
+    this._resource = null;
+  }
+
+  static connect(opts: XmppClientOptions): Promise<XmppClient> {
+    return new Promise((resolve, reject) => {
+      let socket = new net.Socket();
+      socket.on("error", reject);
+
+      socket.connect(opts.port || 5222, opts.host, async () => {
+        socket.removeListener("error", reject);
+        try {
+          let status = 1;
+          while (status) {
+            if (status === STATUS_STARTTLS)
+              socket = await upgradeTls(socket, opts.host);
+            status = await xmppStream(
+              socket,
+              init(
+                socket,
+                opts.host,
+                opts.username,
+                opts.password,
+                opts.resource
+              )
+            );
+          }
+
+          const client = new XmppClient();
+          client._socket = socket;
+          client._host = opts.host;
+          client._username = opts.username;
+          client._resource = opts.resource;
+          socket.on("data", client._onData);
+          socket.on("error", client._onError);
+          resolve(client);
+        } catch (err) {
+          socket.destroy();
+          reject(err);
+        }
+      });
+    });
+  }
+
+  disconnect(): void {
+    this._socket.removeListener("data", this._onData);
+    this._socket.removeListener("error", this._onError);
+    this._socket.end();
+  }
+
+  get host(): string {
+    return this._host;
+  }
+
+  get username(): string {
+    return this._username;
+  }
+
+  get resource(): string {
+    return this._resource;
+  }
+
+  private _onData(chunk: Buffer): void {
+    try {
+      const str = chunk.toString("utf8");
+      const xml = parseXml(str);
+      for (const c of xml.children) this.emit("stanza", c);
+    } catch (err) {
+      this.emit("error", err);
+    }
+  }
+
+  private _onError(err: Error): void {
+    this._socket.end();
+    this.emit("error", err);
+  }
+
+  send(msg: string): void {
+    this._socket.write(msg);
+  }
+}

--- a/lib/xmpp-client.ts
+++ b/lib/xmpp-client.ts
@@ -383,7 +383,10 @@ export default class XmppClient extends EventEmitter {
   }
 
   close(): void {
-    this._socket.end("</stream>");
+    this._socket.end("</stream:stream>");
+    this._socket.removeAllListeners("data");
+    this._socket.removeAllListeners("error");
+    this.emit("close");
   }
 
   ref(): void {


### PR DESCRIPTION
I don't find the issue section so I tried to describe it here
CPE ----> ACS
> Hypertext Transfer Protocol
    POST /acs HTTP/1.1\r\n
        [Expert Info (Chat/Sequence): POST /acs HTTP/1.1\r\n]
            [POST /acs HTTP/1.1\r\n]
            [Severity level: Chat]
            [Group: Sequence]
        Request Method: POST
        Request URI: /acs
        Request Version: HTTP/1.1
    Host: 10.86.0.253:9090\r\n
    Content-Type: text/xml; charset="utf-8"\r\n
    Connection: Keep-Alive\r\n
    Content-Length: 4007\r\n
        [Content length: 4007]
    \r\n
    [Full request URI: http://10.86.0.253:9090/acs]
    [HTTP request 1/29]
    [Response in frame: 43030]
    [Next request in frame: 43037]
    File Data: 4007 bytes


ACS --> CPE

> Hypertext Transfer Protocol
    HTTP/1.1 200 OK\r\n
        [Expert Info (Chat/Sequence): HTTP/1.1 200 OK\r\n]
            [HTTP/1.1 200 OK\r\n]
            [Severity level: Chat]
            [Group: Sequence]
        Response Version: HTTP/1.1
        Status Code: 200
        [Status Code Description: OK]
        Response Phrase: OK
    Server: nginx/1.20.2\r\n
    Date: Wed, 29 Mar 2023 06:24:06 GMT\r\n
    Content-Type: text/xml; charset="utf-8"\r\n
    Content-Length: 522\r\n
        [Content length: 522]
    Connection: keep-alive\r\n
    SOAPServer: GenieACS/1.2.9+20230312100821\r\n
    **Set-Cookie: session=7beeba1c9f45bb5a\r\n**
    \r\n
    [HTTP response 1/29]
    [Time since request: 0.211638476 seconds]
    [Request in frame: 42992]
    [Next request in frame: 43037]
    [Next response in frame: 43049]
    [Request URI: http://10.86.0.253:9090/acs]
    File Data: 522 bytes

CPE --> ACS

> Hypertext Transfer Protocol
    POST /acs HTTP/1.1\r\n
        [Expert Info (Chat/Sequence): POST /acs HTTP/1.1\r\n]
            [POST /acs HTTP/1.1\r\n]
            [Severity level: Chat]
            [Group: Sequence]
        Request Method: POST
        Request URI: /acs
        Request Version: HTTP/1.1
    Host: 10.86.0.253:9090\r\n
    Content-Type: text/xml; charset="utf-8"\r\n
    Connection: Keep-Alive\r\n
    Content-Length: 0\r\n
        [Content length: 0]
    **Cookie: session=7beeba1c9f45bb5a\r\n**
        **Cookie pair: session=7beeba1c9f45bb5a**
    \r\n
    [Full request URI: http://10.86.0.253:9090/acs]
    [HTTP request 2/29]
    [Prev request in frame: 42992]
    [Response in frame: 43049]
    [Next request in frame: 43052]

ACS --> CPE

Hypertext Transfer Protocol
    HTTP/1.1 400 Bad Request\r\n
        [Expert Info (Chat/Sequence): HTTP/1.1 400 Bad Request\r\n]
            [HTTP/1.1 400 Bad Request\r\n]
            [Severity level: Chat]
            [Group: Sequence]
        Response Version: HTTP/1.1
        **Status Code: 400
        [Status Code Description: Bad Request]
        Response Phrase: Bad Request**
    Server: nginx/1.20.2\r\n
    Date: Wed, 29 Mar 2023 06:24:07 GMT\r\n
    Content-Length: 15\r\n
        [Content length: 15]
    Connection: keep-alive\r\n
    \r\n
    [HTTP response 2/29]
    [Time since request: 0.157839566 seconds]
    [Prev request in frame: 42992]
    [Prev response in frame: 43030]
    [Request in frame: 43037]
    [Next request in frame: 43052]
    [Next response in frame: 43093]
    [Request URI: http://10.86.0.253:9090/acs]
    File Data: 15 bytes
    Data (15 bytes)
        Data: 496e76616c69642073657373696f6e
                  Invalid Session
        [Length: 15]

When CPE sends `1 BOOT` then ACS reply with `Set-Cookie` HTTP/200 response,then CPE `POST` something to ACS but it immediately got 400/Bad request,the log output said it was "Invalid Session",only behave like this on this vendor devices,works so far so good whith other vendors.
I tried to bypass the session Lock function but it still happens , just a little infrequently than before