### PR TITLE
Support HEAD requests on fs endpoint

### DIFF
--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -64,8 +64,8 @@ export async function listener(
   request: IncomingMessage,
   response: ServerResponse
 ): Promise<void> {
-  if (request.method !== "GET") {
-    response.writeHead(405, { Allow: "GET" });
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    response.writeHead(405, { Allow: "GET, HEAD" });
     response.end("405 Method Not Allowed");
     return;
   }
@@ -74,7 +74,7 @@ export async function listener(
   const filename = decodeURIComponent(urlParts.pathname.substring(1));
 
   const log = {
-    message: "Fetch file",
+    message: "Fetch file (" + request.method + ")",
     filename: filename,
     remoteAddress: getRequestOrigin(request).remoteAddress,
   };


### PR DESCRIPTION
Some CPE query the FS endpoint with a `HEAD` request first before downloading the image using a `GET` later on.

Forum thread available here: [forum.genieacs.com/t/http-head-method](https://forum.genieacs.com/t/http-head-method/4022)