### PR TITLE
Device tabs initial implement

### DIFF
--- a/lib/local-cache.ts
+++ b/lib/local-cache.ts
@@ -349,6 +349,7 @@ async function fetchConfig(): Promise<[Config, UiConfig]> {
   const ui = {
     filters: {},
     device: {},
+    deviceTabs: {},
     index: {},
     overview: {},
     pageSize: null,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -511,6 +511,7 @@ export interface Config {
 export interface UiConfig {
   filters: Record<string, unknown>;
   device: Record<string, unknown>;
+  deviceTabs?: Record<string, unknown>;
   index: Record<string, unknown>;
   overview: {
     charts?: Record<string, unknown>;

--- a/ui/app.ts
+++ b/ui/app.ts
@@ -131,6 +131,7 @@ m.route(document.body, "/overview", {
   "/overview": pagify("overview", overviewPage),
   "/devices": pagify("devices", devicesPage),
   "/devices/:id": pagify("devices", devicePage),
+  "/devices/:id/:tab": pagify("devices", devicePage),
   "/faults": pagify("faults", faultsPage),
   "/admin": redirectAdminPage(),
   "/admin/presets": pagify("presets", presetsPage),

--- a/ui/config-page.ts
+++ b/ui/config-page.ts
@@ -297,6 +297,7 @@ export const component: ClosureComponent = (): Component => {
           { name: "filters", prefix: "ui.filters.", data: [] },
           { name: "index page", prefix: "ui.index.", data: [] },
           { name: "device page", prefix: "ui.device.", data: [] },
+          { name: "device tab page", prefix: "ui.deviceTabs.", data: [] },
         ];
 
         if (confs.fulfilled) {

--- a/ui/css/app.css
+++ b/ui/css/app.css
@@ -810,3 +810,49 @@ td,
 th {
   line-height: normal;
 }
+
+/* tabsystem on device page */
+div.tab {
+  display: inline-block;
+  overflow: visible;
+  position: absolute;
+  width: 100%;
+
+  & > div.tab_content {
+    padding: 10px 10px;
+    border-top: 1px solid var(--color1);
+  }
+
+  & > ul {
+    font-weight: bold;
+    display: inline-block;
+    padding: 0;
+    margin: 0;
+
+    & > li {
+      background-color: var(--color1);
+      display: inline-block;
+      border-top-left-radius: 6px;
+      border-top-right-radius: 6px;
+      border-top: 1px solid var(--color1);
+      border-left: 1px solid var(--color1);
+      border-right: 1px solid var(--color1);
+      transition: background-color var(--fade);
+      &.active,
+      &:hover {
+        background-color: white;
+      }
+
+      & > a,
+      & > a:visited,
+      & > a:hover {
+        display: inline-block;
+        min-width: 140px;
+        color: var(--color4);
+        text-decoration: none;
+        background: none;
+        padding: 8px;
+      }
+    }
+  }
+}

--- a/ui/device-page.ts
+++ b/ui/device-page.ts
@@ -34,13 +34,14 @@ export function init(
   return Promise.resolve({
     deviceId: args.id,
     deviceFilter: ["=", ["PARAM", "DeviceID.ID"], args.id],
+    tab: args.tab,
   });
 }
 
 export const component: ClosureComponent = (): Component => {
   return {
     view: (vnode) => {
-      document.title = `${vnode.attrs["deviceId"]} - Devices - GenieACS`;
+      document.title = `${vnode.attrs["deviceId"]} - Device ${vnode.attrs["tab"]} - GenieACS`;
 
       const dev = store.fetch("devices", vnode.attrs["deviceFilter"]);
       if (!dev.value.length) {
@@ -53,15 +54,47 @@ export const component: ClosureComponent = (): Component => {
         );
       }
 
+
       const conf = config.ui.device;
+      const deviceTabs = config.ui.deviceTabs;
+      
       const cmps = [];
-
-      for (const c of Object.values(conf)) {
+      
+      if (Object.keys(deviceTabs).length > 0) {
+        const tabActive = { [vnode.attrs["tab"]||deviceTabs[0]["route"]]: "active" };
+        const tabs = [];
+        const tabContent = [];
+        for (const [k,c] of Object.entries(deviceTabs)) {
+          tabs.push(
+            m("li",{
+              "class": tabActive[c["route"]],
+            },[
+              m("a", {
+                href: `#!/devices/${vnode.attrs["deviceId"]}/${c["route"]}`,
+              },c["label"])
+            ])
+          )
+          if (tabActive[c["route"]]){
+            for (const comp of Object.values(c["components"])) {
+              tabContent.push(
+                m.context({ device: dev.value[0], deviceQuery: dev }, comp["type"], comp)
+              );  
+            }  
+          }
+        }
         cmps.push(
-          m.context({ device: dev.value[0], deviceQuery: dev }, c["type"], c)
+          m("div.tab",[
+            m("ul",tabs),
+            m("div.tab_content", tabContent)
+          ])
         );
+      }else{
+        for (const c of Object.values(conf)) {
+          cmps.push(
+            m.context({ device: dev.value[0], deviceQuery: dev }, c["type"], c)
+          );
+        }  
       }
-
       return [m("h1", vnode.attrs["deviceId"]), cmps];
     },
   };


### PR DESCRIPTION
Hello @zaidka , as discussed on [forum thread](https://forum.genieacs.com/t/ui-suggestion-tabbed-component-inside-device-page/2708) here i come with a suggestion for device-page tabbed system, this implementation works without break old device-page configuration, if user want to use it, just don't fill the "device tab page" configuration, but if so, the "device tab page" configuration will be used and all configuration in "device page" will be ignored, as suggested on mentioned forum thread, the system routing, naming and content is fully customizable by the user.

## Features needed
- [X] Tab system without breaking-changes
- [ ] Wizard configuration
- [ ] Documentation

## Demo
![](https://global.discourse-cdn.com/standard17/uploads/genieacs/original/2X/2/2f6681dba13f1c488ea00017d75866b4964378c0.gif)

### Device tab parameters
- label [mandatory] (The displayed name of tab)
- route [mandatory] (The routing name of the tab, that will be like #!/device/< ID >/< ROUTE >)
- components [mandatory] (The components that should be visible on current tab)

#### My notes
  When i developed this feature some things could look redundant like "device" and "deviceTabs" on ui config, but thinking in retrocompability this way looks better in my vision, any comments, questions and suggestions are welcome, some features wasn't developed yet because i need a feedback from genieacs community before proceed.

Best regards.