### PR TITLE
Feature/mandatory spv

### DIFF
--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -406,6 +406,20 @@ parameterValues key. For example:
     parameterValues: [["InternetGatewayDevice.ManagementServer.UpgradesManaged", false], ["InternetGatewayDevice.Time.Enable", true], ["InternetGatewayDevice.Time.NTPServer1", "pool.ntp.org"]]
   }
 
+By default, only the parameters that have been changed will be sent to the CPE.
+It is implemented this way in order to avoid unnecessary connection requests. if
+a parameter must be setted even if it has not been changed, a ``true`` value can
+be passed in the forth position to indicate that the parameter must be setted.
+It might be usefull for diagnostic commands where restarting the CPE causes a
+desynchronization between the CPE and the ACS. For example:
+
+.. code:: javascript
+
+  {
+    name: "setParameterValues",
+    parameterValues: [["InternetGatewayDevice.TraceRouteDiagnostics.Host", 'www.google.com', 'xsd:string', true]]
+  }
+
 ``addObject``
 ~~~~~~~~~~~~~
 

--- a/lib/cwmp.ts
+++ b/lib/cwmp.ts
@@ -694,8 +694,12 @@ async function nextRpc(sessionContext: SessionContext): Promise<void> {
       // Set channel in case params array is empty
       sessionContext.channels[`task_${task._id}`] = 0;
       for (const p of task.parameterValues) {
+        // Check if the mandatory flag is set
+        let mandatory = false;
+        if (p && p[3] && p[3] === true) mandatory = true;
+
         session.addProvisions(sessionContext, `task_${task._id}`, [
-          ["value", p[0], p[1]],
+          ["value", p[0], p[1], mandatory],
         ]);
       }
 

--- a/lib/default-provisions.ts
+++ b/lib/default-provisions.ts
@@ -93,11 +93,17 @@ export function value(
   )
     throw new Error("Invalid arguments");
 
-  let attr: string, val: any;
+  let attr: string, val: any, mandatory = false;
 
-  if (provision.length === 3) {
+  // Test against the default task, with three arguments or with four arguments
+  // that brings the mandatory flag.
+  if (
+    provision.length === 3 ||
+    (provision.length === 4 && provision[0] === "value")
+  ) {
     attr = "value";
     val = provision[2];
+    mandatory = (provision[3] && provision[3] === true);
   } else {
     attr = (provision[2] as string) || "";
     val = provision[3];
@@ -117,7 +123,10 @@ export function value(
     pathGet: 1,
     pathSet: null,
     attrGet: { [attr]: 1 },
-    attrSet: { [attr]: val },
+    attrSet: {
+      [attr]: val,
+      mandatory: mandatory,
+    },
     defer: true,
   });
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -67,7 +67,7 @@ export interface AttributeTimestamps {
 export interface AttributeValues {
   object?: boolean;
   writable?: boolean;
-  value?: [string | number | boolean, string?];
+  value?: [string | number | boolean, string?, boolean?];
   notification?: number;
   accessList?: string[];
 }
@@ -110,6 +110,7 @@ export interface SyncState {
     accessList: Set<Path>;
   };
   spv: Map<Path, [string | number | boolean, string]>;
+  spvMandatory: Map<Path, boolean>;
   spa: Map<Path, { notification: number; accessList: string[] }>;
   gpn: Set<Path>;
   gpnPatterns: Map<Path, number>;
@@ -174,7 +175,7 @@ export interface Task {
   _id?: string;
   name: string;
   parameterNames?: string[];
-  parameterValues?: [string, string | number | boolean, string?][];
+  parameterValues?: [string, string | number | boolean, string?, boolean?][];
   objectName?: string;
   fileType?: string;
   fileName?: string;
@@ -442,6 +443,7 @@ export interface Declaration {
     value?: [string | number | boolean, string?];
     notification?: number;
     accessList?: string[];
+    mandatory?: boolean;
   };
   defer: boolean;
 }


### PR DESCRIPTION
## Resume
- Added a boolean flag that can be passed to SPV to force setting the parameter in the CPE even though the value in ACS is the same.
- Added the reference in API for the `mandatory` flag.

## Explanation:
In [Forum: SetParameterValue set value that already exists](https://forum.genieacs.com/t/setparametervalue-set-value-that-already-exists/927) is requested a mandatory flag that can bypass the ACS verification of the values that are being changed in order to override values that are not synchronized between the ACS and the CPE.
The previous solution was to do a GPV before the SPV or do a SPV with a dummy value before doing the real SPV. The first approach has the inconvenience of doing two `Connection Requests` as it can scale up quickly in a system with thousands of routers. The second approach has the inconvenience of the dummy value that might cause side effects.

## What was implemented:
This pull request adds a boolean flag to the SPV task known as `mandatory`. It bypasses the validation of the value to send to the device even though it is the same as the one defined in genieacs.
This feature is implemented for the API. It might be trivial to extend this feature to be used with `declare`.
It does not affect old systems that uses the old way of sending the SPV task.

## What changed:
### Before:
```
{
    name: "setParameterValues",
    parameterValues: [["InternetGatewayDevice.TraceRouteDiagnostics.Host", 'www.google.com', 'xsd:string']]
  }
```

### Now:
Any of these will work fine.
```
{
    name: "setParameterValues",
    parameterValues: [["InternetGatewayDevice.TraceRouteDiagnostics.Host", 'www.google.com', 'xsd:string']]
  }
```
```
{
    name: "setParameterValues",
    parameterValues: [["InternetGatewayDevice.TraceRouteDiagnostics.Host", 'www.google.com', 'xsd:string', false]]
  }
```
```
{
    name: "setParameterValues",
    parameterValues: [["InternetGatewayDevice.TraceRouteDiagnostics.Host", 'www.google.com', 'xsd:string', true]]
  }
```