### PR TITLE
Empty `connectionRequestUrl` causes the NBI to crash.

### DIFF
--- a/lib/api-functions.ts
+++ b/lib/api-functions.ts
@@ -101,6 +101,7 @@ export async function connectionRequest(
     ).value || [""])[0];
   }
 
+  if (connectionRequestUrl === "") throw new Error("empty connectionRequestURL");
   const remoteAddress = new URL(connectionRequestUrl).hostname;
 
   const evalCallback = (exp): Expression => {

--- a/lib/connection-request.ts
+++ b/lib/connection-request.ts
@@ -80,6 +80,7 @@ export async function httpConnectionRequest(
   _debug: boolean,
   deviceId: string,
 ): Promise<string> {
+  if (address === "") return "URL is empty";
   const url = new URL(address);
   if (url.protocol !== "http:")
     return "Invalid connection request URL or protocol";

--- a/lib/nbi.ts
+++ b/lib/nbi.ts
@@ -296,7 +296,12 @@ async function handler(
           const status = await apiFunctions.connectionRequest(
             deviceId,
             flattenDevice(dev),
-          );
+          ).catch((err)=>{
+            response.writeHead(503, "An error occured", {
+              "Content-Type": "application/json",
+            });
+            response.end(JSON.stringify(err.message));
+          });
           if (status) {
             response.writeHead(504, status);
             response.end(status);
@@ -379,7 +384,14 @@ async function handler(
         ) as number;
       }
 
-      let status = await apiFunctions.connectionRequest(deviceId, device);
+      let status = undefined
+      try{
+        status = await apiFunctions.connectionRequest(deviceId, device);
+      } catch{
+        response.writeHead(503);
+        response.end("Connection to device was not successfull");
+        return
+      }
       if (!status) {
         const sessionStarted = await apiFunctions.awaitSessionStart(
           deviceId,

--- a/lib/ui/api.ts
+++ b/lib/ui/api.ts
@@ -619,7 +619,15 @@ router.post("/devices/:id/tasks", async (ctx) => {
 
   const lastInform = device["Events.Inform"].value[0] as number;
 
-  let status = await apiFunctions.connectionRequest(deviceId, device);
+  let status = undefined;
+
+  try {
+    status = await apiFunctions.connectionRequest(deviceId, device);
+  } catch {
+    status = "Could not connect to device";
+  }
+
+
   if (!status) {
     const sessionStarted = await apiFunctions.awaitSessionStart(
       deviceId,


### PR DESCRIPTION
In genieacs version `1.2.9` requests made to a device with an empty string as `connectionRequestUrl` will crash the `nbi` and will also kill `ui` processes if we summon such a device.

This PR should fix this problem.

I'm not that familiar with typescript so I'm sorry if there are mistakes.

i haven't tested it with the `master` branch yet but this fix works at least with version `1.2.9`

The following error was thrown by nbi before when the `connectionRequestUrl` was empty
```
exceptionName="TypeError" exceptionMessage="Invalid URL: " exceptionStack="
    TypeError [ERR_INVALID_URL]: Invalid URL: 
    at new NodeError (internal/errors.js:322:7)
    at new URL (internal/url.js:346:5)
    at tn (/opt/genieacs/v1.2.9/genieacs-nbi:2:45996)
    at /opt/genieacs/v1.2.9/genieacs-nbi:2:58583
    at processTicksAndRejections (internal/process/task_queues.js:95:5)"
```