### PR TITLE
make sandbox script execution timeout configurable via SCRIPT_TIMEOUT

### DIFF
--- a/docs/environment-variables.rst
+++ b/docs/environment-variables.rst
@@ -26,6 +26,12 @@ EXT_TIMEOUT
 
   Default: ``3000``
 
+SCRIPT_TIMEOUT
+  Timeout (in milliseconds) for executing provision and virtual parameter
+  scripts.
+
+  Default: ``50``
+
 DEBUG_FILE
   File to dump CPE debug log.
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -61,6 +61,7 @@ const options = {
 
   DOWNLOAD_TIMEOUT: { type: "int", default: 3600 },
   EXT_TIMEOUT: { type: "int", default: 3000 },
+  SCRIPT_TIMEOUT: { type: "int", default: 50 },
   MAX_CACHE_TTL: { type: "int", default: 86400 },
   DEBUG_FILE: { type: "path", default: "" },
   DEBUG_FORMAT: { type: "string", default: "yaml" },

--- a/lib/sandbox.ts
+++ b/lib/sandbox.ts
@@ -6,6 +6,7 @@ import * as logger from "./logger.ts";
 import * as scheduling from "./scheduling.ts";
 import Path from "./common/path.ts";
 import { Fault, SessionContext, ScriptResult } from "./types.ts";
+import * as config from "./config.ts";
 
 // Used for throwing to exit user script and commit
 const COMMIT = Symbol();
@@ -372,7 +373,10 @@ export async function run(
   let ret, status;
 
   try {
-    ret = script.runInContext(context, { displayErrors: false, timeout: 50 });
+    ret = script.runInContext(context, {
+      displayErrors: false,
+      timeout: config.get("SCRIPT_TIMEOUT") as number,
+    });
     status = 0;
   } catch (err) {
     if (err === COMMIT) {


### PR DESCRIPTION
The script execution timeout in the sandbox was hardcoded to 50ms.
This adds a new `SCRIPT_TIMEOUT` environment variable so that users
can configure the timeout for provision and virtual parameter scripts.