### PR TITLE
fix(nbi): add optional API key authentication (CVE-2025-56015)

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -37,6 +37,7 @@ const options = {
   NBI_SSL_KEY: { type: "string", default: "" },
   NBI_LOG_FILE: { type: "path", default: "" },
   NBI_ACCESS_LOG_FILE: { type: "path", default: "" },
+  NBI_AUTHENTICATION_KEY: { type: "string", default: "" },
 
   FS_WORKER_PROCESSES: { type: "int", default: 0 },
   FS_PORT: { type: "int", default: 7567 },

--- a/lib/nbi.ts
+++ b/lib/nbi.ts
@@ -1,6 +1,7 @@
 import * as vm from "node:vm";
 import { IncomingMessage, ServerResponse } from "node:http";
 import { Collection, ObjectId } from "mongodb";
+import * as config from "./config.ts";
 import { getRevision, getConfig } from "./ui/local-cache.ts";
 import { filesBucket, collections } from "./db/db.ts";
 import { optimizeProjection } from "./db/util.ts";
@@ -31,6 +32,9 @@ const VIRTUAL_PARAMETERS_REGEX =
   /^\/virtual_parameters\/([a-zA-Z0-9\-_%]+)\/?$/;
 const FAULTS_REGEX = /^\/faults\/([a-zA-Z0-9\-_%:]+)\/?$/;
 
+// Optional API key authentication for NBI endpoints (CVE-2025-56015)
+const NBI_AUTHENTICATION_KEY = config.get("NBI_AUTHENTICATION_KEY") as string;
+
 async function getBody(request: IncomingMessage): Promise<Buffer> {
   const chunks: Buffer[] = [];
   let readableEnded = false;
@@ -56,6 +60,21 @@ export async function listener(
     request.url,
     (origin.encrypted ? "https://" : "http://") + origin.host,
   );
+
+  // API key authentication check (CVE-2025-56015)
+  // When NBI_AUTHENTICATION_KEY is configured, require x-api-key header
+  if (
+    NBI_AUTHENTICATION_KEY &&
+    request.headers["x-api-key"] !== NBI_AUTHENTICATION_KEY
+  ) {
+    logger.accessWarn({
+      remoteAddress: origin.remoteAddress,
+      message: `${request.method} ${url.pathname} - 401 Unauthorized (invalid or missing API key)`,
+    });
+    response.writeHead(401, { "Content-Type": "text/plain" });
+    response.end("401 Unauthorized");
+    return;
+  }
 
   const body = await getBody(request).catch(() => null);
   // Ignore incomplete requests


### PR DESCRIPTION
## Summary

Add optional API key authentication to the NBI REST API endpoint to address CVE-2025-56015.

## Security Issue

The NBI endpoint (port 7557) allows unauthenticated access to sensitive data including:
- User credentials (password hashes and salts)
- Device configurations
- Provisioning scripts
- File metadata

This vulnerability is tracked as **CVE-2025-56015** and has a CVSS score of 7.5 (High).

## Solution

Add `NBI_AUTHENTICATION_KEY` configuration option that enables API key authentication:

- When configured, all NBI requests must include `x-api-key` header
- Invalid/missing keys return 401 Unauthorized
- Failed attempts are logged at warning level
- When unset, behavior is unchanged (backwards compatible)

## Usage

```bash
# In genieacs.env
NBI_AUTHENTICATION_KEY=your-secret-key-here
```

```bash
# API requests must include the header
curl -H "x-api-key: your-secret-key-here" http://localhost:7557/devices
```

## Test Plan

- [x] Build passes
- [ ] Manual testing with/without API key
- [ ] Verify backwards compatibility when key is not set

## Related

- Closes #374 (original feature request from 2022)
- Fixes CVE-2025-56015
- Forum discussion: https://forum.genieacs.com/t/secure-rest-api-endpoints-of-genieacs-nbi/1093